### PR TITLE
Remove console log

### DIFF
--- a/src/js/content_script.js
+++ b/src/js/content_script.js
@@ -36,8 +36,6 @@ console.log('Content script loaded.');
                 console.log('Exact pattern:', pattern, 'match:', match); // Debug log
                 return match;
             });
-            
-            console.log('Domain is blacklisted:', isBlacklisted); // Debug log
             if (callback) callback(isBlacklisted);
         });
     }


### PR DESCRIPTION
@Bigsy  Hi, thanks for the very useful extension! 

I found there are some console logs recently which show up consistently on each page load, without even using the open new tab functionality, which can get in the way of developing other software. Would it be okay to remove this one?